### PR TITLE
Added support for Blender 3.3+ .obj operators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 bl_info = {
     "name" : "JRemesh Tools",
-    "author" : "jayanam",
+    "author" : "jayanam, Kevin C. Burke (@blastframe)",
     "description" : "Quad Remesh tools for Blender 2.8 - 3.x",
     "blender" : (2, 80, 0),
     "version" : (0, 3, 2, 2),

--- a/jrt_remesh_op.py
+++ b/jrt_remesh_op.py
@@ -57,6 +57,8 @@ class JRT_OT_Remesh(Operator):
 
         active_obj_name = context.active_object.name
 
+        min_version = (3, 3, 0)
+
         if self.is_instant_meshes(context):
             try:
                
@@ -71,25 +73,39 @@ class JRT_OT_Remesh(Operator):
                 output = os.path.join(tmp_dir, 'remeshed_object.obj')
 
                 # Export original object
-                bpy.ops.export_scene.obj(filepath=orig,
-                                            check_existing=False,
-                                            use_selection=True,
-                                            use_mesh_modifiers=True,
-                                            use_edges=True,
-                                            use_smooth_groups=False,
-                                            use_smooth_groups_bitflags=False,
-                                            use_normals=True,
-                                            use_uvs=True )
+                if min_version > bpy.app.version:
+                    bpy.ops.export_scene.obj(filepath=orig,
+                                                check_existing=False,
+                                                use_selection=True,
+                                                use_mesh_modifiers=True,
+                                                use_edges=True,
+                                                use_smooth_groups=False,
+                                                use_smooth_groups_bitflags=False,
+                                                use_normals=True,
+                                                use_uvs=True )
+                else:
+                    bpy.ops.wm.obj_export(filepath=orig,
+                                        check_existing=False,
+                                        export_selected_objects=True,
+                                        apply_modifiers=True,
+                                        export_smooth_groups=False,
+                                        smooth_group_bitflags=False,
+                                        export_normals=True,
+                                        export_uv=True
+                                        )
 
                 orig_object = bpy.data.objects[active_obj_name]
 
                 self.do_remesh(app_path, orig, output, context)
 
                 # Import remeshed object
-                bpy.ops.import_scene.obj(filepath=output,
-                                        use_split_objects=False,
-                                        use_smooth_groups=False,
-                                        use_image_search=False)
+                if min_version > bpy.app.version:
+                    bpy.ops.import_scene.obj(filepath=output,
+                                            use_split_objects=False,
+                                            use_smooth_groups=False,
+                                            use_image_search=False)
+                else:
+                    bpy.ops.wm.obj_import(filepath=output)
 
                 # Post import remeshed object                    
                 remeshed_object = bpy.context.selected_objects[0]


### PR DESCRIPTION
Blender 3.3 introduced a new default .obj import & export operators. This patch adds support for this.